### PR TITLE
カレンダースワイプ時、固まるバグを修正

### DIFF
--- a/main.js
+++ b/main.js
@@ -1006,6 +1006,7 @@ function setupSwipe() {
   let activePointerId = null;
   let rafId = null;
   let pendingX = 0;
+  let isAnimating = false;
 
   const setTranslate = (x) => {
     wrapper.style.transform = `translate3d(${x}px, 0, 0)`;
@@ -1020,6 +1021,7 @@ function setupSwipe() {
   };
 
   const onStart = (clientX, clientY, pointerId) => {
+    if (isAnimating) return;
     startX = clientX;
     startY = clientY;
     dx = 0;
@@ -1051,9 +1053,17 @@ function setupSwipe() {
     if (shouldSlide) {
       if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
       setTranslate(dx < 0 ? -width : width);
-      wrapper.addEventListener('transitionend', () => {
+      isAnimating = true;
+      const fallback = setTimeout(() => {
         wrapper.style.transition = '';
         wrapper.style.transform = '';
+        isAnimating = false;
+      }, 500);
+      wrapper.addEventListener('transitionend', () => {
+        clearTimeout(fallback);
+        wrapper.style.transition = '';
+        wrapper.style.transform = '';
+        isAnimating = false;
         goMonth(dir, false);
       }, { once: true });
     } else {
@@ -1068,43 +1078,54 @@ function setupSwipe() {
     dragging = false;
   };
 
-  // Pointer Events（iOS 13+）
-  wrapper.addEventListener('pointerdown', (e) => {
-    if (e.pointerType === 'mouse' && e.button !== 0) return;
-    wrapper.setPointerCapture?.(e.pointerId);
-    onStart(e.clientX, e.clientY, e.pointerId);
-  }, { passive: true });
+  const hasPointer = !!window.PointerEvent;
 
-  wrapper.addEventListener('pointermove', (e) => {
-    if (activePointerId !== e.pointerId) return;
-    const moved = onMove(e.clientX, e.clientY);
-    if (moved) e.preventDefault();
-  }, { passive: false });
+  if (hasPointer) {
+    // Pointer Events（iOS 13+）
+    wrapper.addEventListener('pointerdown', (e) => {
+      if (e.pointerType === 'mouse' && e.button !== 0) return;
+      wrapper.setPointerCapture?.(e.pointerId);
+      onStart(e.clientX, e.clientY, e.pointerId);
+    }, { passive: true });
 
-  wrapper.addEventListener('pointerup', (e) => {
-    if (activePointerId !== e.pointerId) return;
-    onEnd();
-  }, { passive: true });
+    wrapper.addEventListener('pointermove', (e) => {
+      if (activePointerId !== e.pointerId) return;
+      const moved = onMove(e.clientX, e.clientY);
+      if (moved) e.preventDefault();
+    }, { passive: false });
 
-  wrapper.addEventListener('pointercancel', () => {
-    onEnd();
-  }, { passive: true });
+    wrapper.addEventListener('pointerup', (e) => {
+      if (activePointerId !== e.pointerId) return;
+      onEnd();
+    }, { passive: true });
 
-  // フォールバック（古い環境）
-  wrapper.addEventListener('touchstart', (e) => {
-    if (!e.touches[0]) return;
-    onStart(e.touches[0].clientX, e.touches[0].clientY, 'touch');
-  }, { passive: true });
+    wrapper.addEventListener('pointercancel', () => {
+      onEnd();
+    }, { passive: true });
 
-  wrapper.addEventListener('touchmove', (e) => {
-    if (!e.touches[0]) return;
-    const moved = onMove(e.touches[0].clientX, e.touches[0].clientY);
-    if (moved) e.preventDefault();
-  }, { passive: false });
+    window.addEventListener('pointerup', (e) => {
+      if (activePointerId !== null && activePointerId === e.pointerId) onEnd();
+    }, { passive: true });
+    window.addEventListener('pointercancel', () => {
+      if (activePointerId !== null) onEnd();
+    }, { passive: true });
+  } else {
+    // フォールバック（古い環境）
+    wrapper.addEventListener('touchstart', (e) => {
+      if (!e.touches[0]) return;
+      onStart(e.touches[0].clientX, e.touches[0].clientY, 'touch');
+    }, { passive: true });
 
-  wrapper.addEventListener('touchend', () => {
-    onEnd();
-  }, { passive: true });
+    wrapper.addEventListener('touchmove', (e) => {
+      if (!e.touches[0]) return;
+      const moved = onMove(e.touches[0].clientX, e.touches[0].clientY);
+      if (moved) e.preventDefault();
+    }, { passive: false });
+
+    wrapper.addEventListener('touchend', () => {
+      onEnd();
+    }, { passive: true });
+  }
 }
 
 /* ────────────────────────────────────────────────────────────


### PR DESCRIPTION
原因（複合的）

Pointer Events と Touch Events の二重処理
iOS Safariでは pointer と touch が両方発火することがあり、
activePointerId が上書きされて状態が崩れ、スワイプが固まる。

アニメーション中に次のスワイプが開始される
連続スワイプで transition 中に新しい操作が入り、
transform が戻らない／dragging が解除されない状態になった。

pointerup/pointercancel の取りこぼし
スワイプが速いと、wrapper から指が外れて
pointerup が届かず、状態が終了しないことがあった。

対処

Pointer Events が使える場合は Touch を無効化
→ 二重発火を防止。

アニメーション中は新規スワイプを禁止
→ 状態の上書きや競合を防止。

transitionend が来ない場合のフォールバック解除
→ 500ms後に強制的に復帰。

window でも pointerup/cancel を拾う
→ 取りこぼし防止。

